### PR TITLE
Disable method visibility checks for tests

### DIFF
--- a/standards/Tighten/ruleset.xml
+++ b/standards/Tighten/ruleset.xml
@@ -34,6 +34,11 @@
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
 
+    <!-- Disable "Visibility must be declared on method" rule for test files -->
+    <rule ref="Squiz.Scope.MethodScope">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+
     <!-- Disable camel caps rule for tests -->
     <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
         <exclude-pattern>*/tests/*</exclude-pattern>


### PR DESCRIPTION
Since Tlint requires no method visibility in tests files, phpcs should not complain about it.