### PR TITLE
Lower PHP version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^7.3|^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "squizlabs/php_codesniffer": "^3.5"
     },


### PR DESCRIPTION
This PR lowers the PHP version requirement to `7.3`, so that we can also lower `tighten/duster`'s minimum required version. 

Tested this using PHP 7.3 and was able to successfully run `composer install`, `tlint`, `phpcs`, and phpunit example test.