### PR TITLE
Remove duplicate php version in test run

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
         strategy:
             matrix:
                 os: [Ubuntu, Windows, macOS]
-                php: [7.3, 7.3, 7.4, 8.0]
+                php: [7.3, 7.4, 8.0]
 
                 include:
                   - os: Ubuntu


### PR DESCRIPTION
Remove duplicate php version in test run, that is causing PHP 7.3 tests to run twice