### PR TITLE
Drop support for 7.3 and add 8.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, Windows, macOS]
-        php: [7.4, 8.0]
+        php: [7.4, 8.0, 8.1]
 
         include:
           - os: Ubuntu

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,44 +1,44 @@
 name: Run tests
 
 on:
-    push:
-        branches: [ main ]
-    pull_request:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
-    tests:
-        strategy:
-            matrix:
-                os: [Ubuntu, Windows, macOS]
-                php: [7.3, 7.4, 8.0]
+  tests:
+    strategy:
+      matrix:
+        os: [Ubuntu, Windows, macOS]
+        php: [7.4, 8.0]
 
-                include:
-                  - os: Ubuntu
-                    os-version: ubuntu-latest
+        include:
+          - os: Ubuntu
+            os-version: ubuntu-latest
 
-                  - os: Windows
-                    os-version: windows-latest
+          - os: Windows
+            os-version: windows-latest
 
-                  - os: macOS
-                    os-version: macos-latest
+          - os: macOS
+            os-version: macos-latest
 
-        name: ${{ matrix.os }} - PHP ${{ matrix.php }}
+    name: ${{ matrix.os }} - PHP ${{ matrix.php }}
 
-        runs-on: ${{ matrix.os-version }}
+    runs-on: ${{ matrix.os-version }}
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
 
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php }}
-                  extensions: posix, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
-                  coverage: none
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: posix, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          coverage: none
 
-            - name: Install dependencies
-              run: composer update --prefer-stable --prefer-dist --no-interaction --no-suggest --ignore-platform-reqs
+      - name: Install dependencies
+        run: composer update --prefer-stable --prefer-dist --no-interaction --no-suggest --ignore-platform-reqs
 
-            - name: Run tests
-              run: vendor/bin/phpunit
+      - name: Run tests
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^7.4|^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "squizlabs/php_codesniffer": "^3.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^7.4|^8.0|^8.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "squizlabs/php_codesniffer": "^3.5"
     },


### PR DESCRIPTION
This PR drops support for [EOD PHP 7.3](https://phpreleases.com/api/releases/7.3.33) and adds PHP 8.1.

Related PR: #5 

https://github.com/tighten/duster/issues/37