### PR TITLE
Fix typo and convert warning to blockquote

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
->**Warning** **Tighten Coding Standar** has been archived.  Please use **[Duster](https://github.com/tighten/duster)** instead.
+> [!WARNING]
+> **Tighten Coding Standard** has been archived.  Please use **[Duster](https://github.com/tighten/duster)** instead.
 
 # PHP Coding Standard
 


### PR DESCRIPTION
Convert the warning to blockquote as described in [#16925](https://github.com/orgs/community/discussions/16925) to make it more visible. I considered that it should be a NOTE and not a WARNING, but the original line was marked as a warning, so I left it as a warning.